### PR TITLE
fix: Remove undefined component class

### DIFF
--- a/src/features/table/table-header.tsx
+++ b/src/features/table/table-header.tsx
@@ -40,11 +40,7 @@ export const TableHeader = component$(() => {
           >
             <div class="flex items-center justify-between gap-2">
               <div class="flex items-center gap-2">
-                <ColumnIcon
-                  type={column.type}
-                  kind={column.kind}
-                  class="h-3.5 w-3.5 text-gray-400"
-                />
+                <ColumnIcon type={column.type} kind={column.kind} />
                 <span class="text-sm font-medium text-gray-700">
                   {column.name}
                 </span>


### PR DESCRIPTION
The command:

```bash
pnpm build
```

fails with following error:

```bash
5.542 src/features/table/table-header.tsx:46:19 - error TS2322: Type '{ type: ColumnType; kind: ColumnKind; class: string; }' is not assignable to type 'IntrinsicAttributes & Omit<{ type: ColumnType; kind: ColumnKind; }, `${string}$`> & _Only$<{ type: ColumnType; kind: ColumnKind; }> & ComponentBaseProps & { ...; }'.
5.542   Property 'class' does not exist on type 'IntrinsicAttributes & Omit<{ type: ColumnType; kind: ColumnKind; }, `${string}$`> & _Only$<{ type: ColumnType; kind: ColumnKind; }> & ComponentBaseProps & { ...; }'.
5.542
5.542 46                   class="h-3.5 w-3.5 text-gray-400"
5.542                      ~~~~~
5.542
5.542
5.542 Found 1 error in src/features/table/table-header.tsx:46
5.542
5.558  ELIFECYCLE  Command failed with exit code 2.
5.567
5.567
5.568 /usr/src/app/node_modules/.pnpm/@builder.io+qwik@1.12.0_vite@5.3.5_@types+node@20.14.11_/node_modules/@builder.io/qwik/dist/cli.cjs:4710
5.568       throw new Error(`Type check failed: ${out}`);
5.568             ^
5.568
5.568 Error: Type check failed:
5.568     at /usr/src/app/node_modules/.pnpm/@builder.io+qwik@1.12.0_vite@5.3.5_@types+node@20.14.11_/node_modules/@builder.io/qwik/dist/cli.cjs:4710:13
5.568     at process.processTicksAndRejections (node:internal/process/task_queues:95:5)
5.568
5.568 Node.js v20.18.2
5.571  ELIFECYCLE  Command failed with exit code 1.
------
```

This PR  removes the missing `class` property for the `ColumnIcon` component.

@leiyre feel free to change/adapt the PR if the class is needed.