### PR TITLE
[BUGFIX] Prevent recursion errors when closing modal for empty datasets

### DIFF
--- a/src/state/columns.ts
+++ b/src/state/columns.ts
@@ -49,7 +49,9 @@ export const useColumnsStore = () => {
 
   const createPlaceholderColumn = $((): Column => {
     const getNextColumnName = (counter = 1): string => {
-      const manyColumnsWithName = activeDataset.value.columns;
+      const manyColumnsWithName = activeDataset.value.columns.filter(
+        (c) => c.id !== TEMPORAL_ID,
+      );
       const newPosibleColumnName = `Column ${manyColumnsWithName.length + 1}`;
 
       if (!manyColumnsWithName.find((c) => c.name === newPosibleColumnName)) {


### PR DESCRIPTION
When closing the prompt modal for an "empty" dataset, the app crashes with the following error:

<img width="1504" alt="Captura de pantalla 2025-02-11 a las 10 18 18" src="https://github.com/user-attachments/assets/2e20f0ee-9324-4cfe-8fa9-fa971c102e0d" />

This PR prevents this by excluding temporal columns when computing the new column name
