### PR TITLE
[CI] configure docker build

### DIFF
--- a/.github/workflows/ci.buld.yml
+++ b/.github/workflows/ci.buld.yml
@@ -78,6 +78,6 @@ jobs:
         uses: docker/build-push-action@v5
         with:
           platforms: ${{ env.PLATFORMS }}
-          tags: ${{ env.SERVER_DOCKER_IMAGE }}:latest
+          tags: ${{ env.DOCKER_IMAGE }}:latest
           labels: ${{ steps.meta.outputs.labels }}
           push: true


### PR DESCRIPTION
This PR allows the generation and publication of docker images. The image tag is based on the branch name. For the branch `ci/build-and-push-docker-image` the generated tag will be [`build-and-push-docker-image`](https://hub.docker.com/layers/argilladev/dataground/build-and-push-docker-image/images/sha256-bf72376f75442381293e157beffdc8b6cad348bb6f54ce683eaf665f30a3e18a). 