### PR TITLE
[BUGFIX] Prevent error when generating multiple columns cells without column references

### DIFF
--- a/src/usecases/generate-cells.ts
+++ b/src/usecases/generate-cells.ts
@@ -78,14 +78,7 @@ export const generateCells = async function* ({
       for (let i = offset; i < limit + offset; i++) {
         if (validatedIdxs?.includes(i)) continue;
 
-        let cell = await getColumnCellByIdx({ idx: i, columnId: column.id });
-
-        if (!cell?.id) {
-          cell = await createCell({
-            cell: { idx: i },
-            columnId: column.id,
-          });
-        }
+        const cell = await getOrCreateCellInDB(column.id, i);
 
         cell.generating = true;
         cells.set(i, cell);
@@ -148,10 +141,7 @@ export const generateCells = async function* ({
     for (let i = offset; i < limit + offset; i++) {
       if (validatedIdxs?.includes(i)) continue;
 
-      let cell = await getColumnCellByIdx({ idx: i, columnId: column.id });
-      if (!cell?.id) {
-        cell = await createCell({ cell: { idx: i }, columnId: column.id });
-      }
+      const cell = await getOrCreateCellInDB(column.id, i);
 
       cell.generating = true;
       yield { cell };
@@ -197,4 +187,20 @@ export const generateCells = async function* ({
     process.updatedAt = new Date();
     await updateProcess(process);
   }
+};
+
+const getOrCreateCellInDB = async (
+  columnId: string,
+  idx: number,
+): Promise<Cell> => {
+  let cell = await getColumnCellByIdx({ idx, columnId });
+
+  if (!cell?.id) {
+    cell = await createCell({
+      cell: { idx },
+      columnId,
+    });
+  }
+
+  return cell;
 };


### PR DESCRIPTION
This PR fixes errors when generating column cells for additional columns that do not include column references. 

For those cases, the cell values exist in the duckdb table (additional columns are a series of null values with the length of the dataset, instead of an empty list), and the condition to create the cell does not match (only match for the first column).