### PR TITLE
[BUGFIX] Disable stop generating while column is not yet created

### DIFF
--- a/src/features/add-column/form/execution-form.tsx
+++ b/src/features/add-column/form/execution-form.tsx
@@ -213,12 +213,11 @@ export const ExecutionForm = component$<SidebarProps>(
                     onSelectedVariables={onSelectedVariables}
                   />
                 </div>
+
                 <div class="absolute bottom-4 flex flex-row items-center justify-end px-6 gap-8 w-full">
-                  <div class="flex items-center gap-1">
-                    {column.process?.isExecuting && (
-                      <div class="h-4 w-4 animate-spin rounded-full border-2 border-primary-100 border-t-transparent" />
-                    )}
-                  </div>
+                  {column.process?.isExecuting && (
+                    <div class="h-4 w-4 animate-spin rounded-full border-2 border-primary-100 border-t-transparent" />
+                  )}
                   <Button
                     key={column.process?.isExecuting?.toString()}
                     look="primary"
@@ -229,9 +228,7 @@ export const ExecutionForm = component$<SidebarProps>(
                     }
                   >
                     {column.process?.isExecuting ? (
-                      <>
-                        <LuStopCircle class="h-6 w-6" />
-                      </>
+                      <LuStopCircle class="h-6 w-6" />
                     ) : (
                       <LuEgg class="w-6 h-6" />
                     )}


### PR DESCRIPTION
The Stop Generating button remains disabled until the column is persisted in DB. Otherwise, the column reference gets wrong.


Closes https://github.com/huggingface/dataground/issues/200