### PR TITLE
[CHORE] Upgrade HF packages

### DIFF
--- a/package.json
+++ b/package.json
@@ -69,7 +69,7 @@
   },
   "dependencies": {
     "@duckdb/node-api": "1.2.2-alpha.19",
-    "@huggingface/hub": "~2.0.0",
+    "@huggingface/hub": "~2.1.0",
     "@huggingface/inference": "~4.0.0",
     "@huggingface/tasks": "^0.19.5",
     "@huggingface/transformers": "^3.5.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: 1.2.2-alpha.19
         version: 1.2.2-alpha.19
       '@huggingface/hub':
-        specifier: ~2.0.0
-        version: 2.0.2
+        specifier: ~2.1.0
+        version: 2.1.0
       '@huggingface/inference':
         specifier: ~4.0.0
         version: 4.0.2
@@ -457,9 +457,10 @@ packages:
   '@gar/promisify@1.1.3':
     resolution: {integrity: sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==}
 
-  '@huggingface/hub@2.0.2':
-    resolution: {integrity: sha512-2ii3hE+K/mwUOyecm9rW6diBfsxNUDUHrNWJzqeFgMAWJ2ShAICxF9HtvYUKK7y0FS8Xnq6F1W+tRZYbnW0PcQ==}
+  '@huggingface/hub@2.1.0':
+    resolution: {integrity: sha512-L+125tAXwCOwVd8n4qQlT20ZJP7I5sEXOLNrIzpgkUG6eMIsGlxT+9hmmiCH/LGmjbXjlcRHoPB8GGT3zCws4A==}
     engines: {node: '>=18'}
+    hasBin: true
 
   '@huggingface/inference@4.0.2':
     resolution: {integrity: sha512-XuWb8ocH7lA5kSdXrGnqshtRz3ocSBzEzxcp5xeAXLjgM1ocoIHq+RW8/Ti0xq3MeRGQWgUkYPCgDV/xgs8p4g==}
@@ -4153,7 +4154,7 @@ snapshots:
   '@gar/promisify@1.1.3':
     optional: true
 
-  '@huggingface/hub@2.0.2':
+  '@huggingface/hub@2.1.0':
     dependencies:
       '@huggingface/tasks': 0.19.11
 


### PR DESCRIPTION
Keep updated HuggingFace packages as much as possible.

- @huggginface/inference -> 4.0.2 (includes [this fix](https://github.com/huggingface/huggingface.js/pull/1507))
- @huggingface/hub -> 2.1.0 