### PR TITLE
[BUGFIX] Export CSV with multiple column types

### DIFF
--- a/src/services/repository/tables/list-table-rows.ts
+++ b/src/services/repository/tables/list-table-rows.ts
@@ -105,7 +105,7 @@ export const exportDatasetTableRows = async ({
   const filePath = path.join(tempDir, `file.${duckdbFormat.toLowerCase()}`);
 
   return await connectAndClose(async (db) => {
-    const coalesceStatement = `COALESCE(${columns.map((column) => getColumnName(column)).join(',')}) IS NOT NULL`;
+    const coalesceStatement = `COALESCE(${columns.map((column) => `CAST (${getColumnName(column)} AS varchar(10))`).join(',')}) IS NOT NULL`;
 
     const selectedColumns = columns
       .map((column) => `${getColumnName(column)} as "${column.name}"`)


### PR DESCRIPTION
The coalesce function expects that all values have the same type. This PR applies a cast to prevent errors.

See https://github.com/duckdb/duckdb/issues/11860