### PR TITLE
[HOTFIX]: Lower case when finding models by id

### DIFF
--- a/src/features/add-column/form/execution-form.tsx
+++ b/src/features/add-column/form/execution-form.tsx
@@ -122,7 +122,9 @@ export const ExecutionForm = component$<SidebarProps>(
 
     const modelProviders = useComputed$(() => {
       const model = models.value.find(
-        (m: Model) => m.id === selectedModelId.value,
+        (m: Model) =>
+          m.id.toLocaleLowerCase() ===
+          selectedModelId.value.toLocaleLowerCase(),
       );
       return model ? model.providers : [];
     });
@@ -184,8 +186,10 @@ export const ExecutionForm = component$<SidebarProps>(
         selectedProvider.value = process.modelProvider!;
       } else {
         const defaultModel =
-          models.value?.find((m: Model) => m.id === DEFAULT_MODEL) ||
-          models.value[0];
+          models.value?.find(
+            (m: Model) =>
+              m.id.toLocaleLowerCase() === DEFAULT_MODEL.toLocaleLowerCase(),
+          ) || models.value[0];
 
         if (!defaultModel) return;
 


### PR DESCRIPTION
This avoids a mismatch when defining a default model with lower case.  