### PR TITLE
Added `--frozen-lockfile` to pnpm install commands for dependencies consistency

### DIFF
--- a/.github/workflows/ci.buld.yml
+++ b/.github/workflows/ci.buld.yml
@@ -23,7 +23,7 @@ jobs:
         cache: 'pnpm'
 
     - name: Install dependencies
-      run: pnpm install
+      run: pnpm install --frozen-lockfile
 
     - name: Test 
       run: pnpm test

--- a/README.md
+++ b/README.md
@@ -38,10 +38,10 @@ Open `http://localhost:3000` in your browser.
 First, [install pnpm](https://pnpm.io/installation) if you haven't already.
 
 ```bash
-git clone https://github.com/huggingface/sheets.git
+git clone https://github.com/huggingface/aisheets.git
 cd sheets
 export HF_TOKEN=your_token_here
-pnpm install
+pnpm install --frozen-lockfile
 pnpm dev
 ```
 

--- a/switch.sh
+++ b/switch.sh
@@ -35,7 +35,7 @@ fi
 
 # Install dependencies with pnpm
 echo "Installing dependencies with pnpm..."
-pnpm install
+pnpm install --frozen-lockfile
 if [ $? -ne 0 ]; then
   echo "Error: pnpm install failed."
   exit 1


### PR DESCRIPTION
Currently, `pnpm install` updates `pnpm-lock.yaml`, which is undesirable as you only want to install dependencies that are already specified in the lockfile by default. It also undermines reproducible and consistent builds for CI/CD operations.

Files with relevant changes:
- README.md
- switch.sh
- .github/workflows/ci.buld.yml