### PR TITLE
🔒 Pin GitHub Actions to commit SHAs

### DIFF
--- a/.github/workflows/ci.buld.yml
+++ b/.github/workflows/ci.buld.yml
@@ -8,16 +8,16 @@ jobs:
 
     steps:
     
-    - uses: actions/checkout@v4
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
 
-    - uses: pnpm/action-setup@v4
+    - uses: pnpm/action-setup@b906affcce14559ad1aafd4ab0e942779e9f58b1  # v4
       name: Install pnpm
       with:
         version: 10
         run_install: false
 
     - name: Install Node.js
-      uses: actions/setup-node@v4
+      uses: actions/setup-node@49933ea5288caeca8642d1e84afbd3f7d6820020  # v4
       with:
         node-version: 20
         cache: 'pnpm'
@@ -39,13 +39,13 @@ jobs:
     needs: build
 
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd  # v6.0.2
       
       - name: Set up QEMU
-        uses: docker/setup-qemu-action@v3
+        uses: docker/setup-qemu-action@c7c53464625b32c7a7e944ae62b3e17d2b600130  # v3
 
       - name: Set up Docker Buildx
-        uses: docker/setup-buildx-action@v3
+        uses: docker/setup-buildx-action@8d2750c68a42422c14e847fe6c8ac0403b4cbd6f  # v3
 
       - name: Setup environment variables
         run: |
@@ -72,13 +72,13 @@ jobs:
           
 
       - name: Login to Docker Hub
-        uses: docker/login-action@v3
+        uses: docker/login-action@c94ce9fb468520275223c153574b00df6fe4bcc9  # v3
         with:
           username: ${{ env.DOCKER_USERNAME }}
           password: ${{ env.DOCKER_PASSWORD }}
 
       - name: Build and push image
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
         with:
           platforms: ${{ env.PLATFORMS }}
           tags: ${{ env.DOCKER_IMAGE }}:${{ env.IMAGE_TAG }}
@@ -87,7 +87,7 @@ jobs:
 
       - name: Push latest image
         if: github.ref == 'refs/heads/stable'
-        uses: docker/build-push-action@v5
+        uses: docker/build-push-action@ca052bb54ab0790a636c9b5f226502c73d547a25  # v5
         with:
           platforms: ${{ env.PLATFORMS }}
           tags: ${{ env.DOCKER_IMAGE }}:latest


### PR DESCRIPTION
## 🔒 Pin GitHub Actions to commit SHAs

This PR pins all GitHub Actions to their exact commit SHA instead of mutable tags or branch names.

**Why?**
Pinning to a SHA prevents supply chain attacks where a tag (e.g. `v4`) could be moved to point to malicious code.

### Changes

| Workflow | Action | Avant | Après | SHA |
|---|---|---|---|---|
| `ci.buld.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `ci.buld.yml` | `pnpm/action-setup` | `v4` | `v4` | `b906affcce14…` |
| `ci.buld.yml` | `actions/setup-node` | `v4` | `v4` | `49933ea5288c…` |
| `ci.buld.yml` | `actions/checkout` | `v4` | `v6.0.2` | `de0fac2e4500…` |
| `ci.buld.yml` | `docker/setup-qemu-action` | `v3` | `v3` | `c7c53464625b…` |
| `ci.buld.yml` | `docker/setup-buildx-action` | `v3` | `v3` | `8d2750c68a42…` |
| `ci.buld.yml` | `docker/login-action` | `v3` | `v3` | `c94ce9fb4685…` |
| `ci.buld.yml` | `docker/build-push-action` | `v5` | `v5` | `ca052bb54ab0…` |
| `ci.buld.yml` | `docker/build-push-action` | `v5` | `v5` | `ca052bb54ab0…` |

> 🤖 Generated by `/github-actions-audit` — [security/pin-actions-to-sha]


Closes huggingface/tracking-issues#62